### PR TITLE
Use official PaddleOCR Python wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Frappe Books addresses a market gap where small businesses face expensive, compl
   - **Billing**: Billing processes by generating bills and tracking payments.
   - **Payments**: Records and tracks payments received and made.
   - **Journal Entries**: Records financial transactions in the general ledger with detailed notes and adjustments.
+  - **Import via OCR**: Quickly create entries by importing documents and extracting text with [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR).
 - **Financial Reports**
   - **General Ledger**: Centralized record of all financial transactions, providing a comprehensive view of accounts.
   - **Profit and Loss Statement**: Summarizes revenues, costs, and expenses to show business profitability.
@@ -98,6 +99,8 @@ To get the dev environment up and running you need to first set up Node.js `v20.
 
 Next, you will need to install [yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable).
 
+If you want to use the optional OCR import feature, make sure you have **Python 3.8+** available on your system.
+
 ### Clone and Run
 
 Once you are through the Pre-requisites, you can run the following commands to
@@ -112,6 +115,9 @@ cd books
 
 # install dependencies
 yarn
+
+# (optional) enable OCR import
+pip install paddleocr
 ```
 
 To run Frappe Books in development mode (with hot reload, etc):

--- a/electron-builder-config.mjs
+++ b/electron-builder-config.mjs
@@ -22,6 +22,7 @@ const frappeBooksConfig = {
     { from: 'log_creds.txt', to: '../creds/log_creds.txt' },
     { from: 'translations', to: '../translations' },
     { from: 'templates', to: '../templates' },
+    { from: 'scripts/paddleocr_cli.py', to: '../paddleocr_cli.py' },
   ],
   files: '**',
   extends: null,

--- a/scripts/paddleocr_cli.py
+++ b/scripts/paddleocr_cli.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import sys, json
+from paddleocr import PaddleOCR
+
+def main():
+    if len(sys.argv) < 2:
+        print('Usage: paddleocr_cli.py <image>', file=sys.stderr)
+        return 1
+    image_path = sys.argv[1]
+    ocr = PaddleOCR(use_angle_cls=False, use_space_char=True, use_gpu=False)
+    result = ocr.ocr(image_path, cls=False)
+    texts = []
+    for res in result:
+        for line in res:
+            if len(line) >= 2:
+                texts.append(line[1][0])
+    print(json.dumps({'text': ' '.join(texts)}, ensure_ascii=False))
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/paddleocr_cli.py
+++ b/scripts/paddleocr_cli.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python3
-import sys, json
-from paddleocr import PaddleOCR
+import sys
+import json
+
+try:
+    from paddleocr import PaddleOCR
+except Exception as e:
+    print(
+        json.dumps({"error": f"PaddleOCR not installed: {e}"}),
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 def main():
     if len(sys.argv) < 2:

--- a/src/utils/ocr.ts
+++ b/src/utils/ocr.ts
@@ -1,0 +1,48 @@
+import { t } from 'fyo';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { execFile } from 'child_process';
+
+/**
+ * Run OCR on the provided image buffer using the official PaddleOCR
+ * Python package. Requires `paddleocr` to be installed in the system
+ * Python environment.
+ */
+export async function ocrBuffer(buffer: Buffer): Promise<string> {
+  const tmpPath = path.join(tmpdir(), `ocr-${randomUUID()}`);
+  const imagePath = path.join(tmpPath, 'input.png');
+  const scriptPath = path.join(__dirname, '../../scripts/paddleocr_cli.py');
+
+  await fs.mkdir(tmpPath, { recursive: true });
+  await fs.writeFile(imagePath, buffer);
+
+  try {
+    const { stdout } = await new Promise<{ stdout: string }>(
+      (resolve, reject) => {
+        execFile(
+          'python3',
+          [scriptPath, imagePath],
+          { encoding: 'utf8' },
+          (err, stdout, stderr) => {
+            if (err) {
+              console.error(stderr);
+              reject(err);
+              return;
+            }
+            resolve({ stdout });
+          }
+        );
+      }
+    );
+
+    const { text } = JSON.parse(stdout) as { text: string };
+    return text;
+  } catch (error) {
+    console.error('PaddleOCR error', error);
+    throw new Error(t`OCR failed: ${String(error)}`);
+  } finally {
+    await fs.rm(tmpPath, { recursive: true, force: true });
+  }
+}

--- a/src/utils/ocr.ts
+++ b/src/utils/ocr.ts
@@ -1,5 +1,5 @@
 import { t } from 'fyo';
-import { promises as fs } from 'fs';
+import fs from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { randomUUID } from 'crypto';
@@ -13,27 +13,50 @@ import { execFile } from 'child_process';
 export async function ocrBuffer(buffer: Buffer): Promise<string> {
   const tmpPath = path.join(tmpdir(), `ocr-${randomUUID()}`);
   const imagePath = path.join(tmpPath, 'input.png');
-  const scriptPath = path.join(__dirname, '../../scripts/paddleocr_cli.py');
+
+  const devScript = path.join(__dirname, '../../scripts/paddleocr_cli.py');
+  const prodScript = path.join(process.resourcesPath, 'paddleocr_cli.py');
+  const scriptPath = fs.existsSync(prodScript) ? prodScript : devScript;
 
   await fs.mkdir(tmpPath, { recursive: true });
   await fs.writeFile(imagePath, buffer);
 
   try {
+    const pythonCmds =
+      process.platform === 'win32'
+        ? ['python', 'python3', 'py']
+        : ['python3', 'python'];
+
     const { stdout } = await new Promise<{ stdout: string }>(
       (resolve, reject) => {
-        execFile(
-          'python3',
-          [scriptPath, imagePath],
-          { encoding: 'utf8' },
-          (err, stdout, stderr) => {
-            if (err) {
-              console.error(stderr);
-              reject(err);
-              return;
-            }
-            resolve({ stdout });
+        const tryRun = (cmds: string[]): void => {
+          if (cmds.length === 0) {
+            reject(new Error('Python is not installed'));
+            return;
           }
-        );
+
+          const cmd = cmds[0];
+          execFile(
+            cmd,
+            [scriptPath, imagePath],
+            { encoding: 'utf8' },
+            (err, stdout, stderr) => {
+              if (err) {
+                if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+                  // try next command
+                  tryRun(cmds.slice(1));
+                } else {
+                  console.error(stderr);
+                  reject(err);
+                }
+                return;
+              }
+              resolve({ stdout });
+            }
+          );
+        };
+
+        tryRun(pythonCmds);
       }
     );
 


### PR DESCRIPTION
## Summary
- add Python helper `paddleocr_cli.py`
- call helper from `ocrBuffer`
- bundle OCR script in build config

## Testing
- `yarn install` *(fails: better-sqlite3 couldn't be built)*
- `yarn test` *(fails: `/usr/bin/env: ‘zsh’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6874b6c6890c83278045e1fcff690229