### PR TITLE
Use official PaddleOCR Python wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Frappe Books development container with OCR
+FROM node:20.18.1-bullseye
+
+# Install system dependencies for Electron and native modules
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    build-essential \
+    libgtk-3-0 libx11-xcb1 libxcomposite1 libxdamage1 libxrandr2 libasound2 \
+    libatk1.0-0 libatk-bridge2.0-0 libxkbcommon0 libxss1 libnss3 libdrm2 libgbm1 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install
+
+COPY . .
+
+# Install PaddleOCR (pinned for compatibility)
+RUN pip3 install paddleocr==2.7.0
+
+ENV ELECTRON_EXTRA_LAUNCH_ARGS=--no-sandbox
+EXPOSE 6969
+
+CMD ["yarn", "dev"]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Frappe Books addresses a market gap where small businesses face expensive, compl
   - **Billing**: Billing processes by generating bills and tracking payments.
   - **Payments**: Records and tracks payments received and made.
   - **Journal Entries**: Records financial transactions in the general ledger with detailed notes and adjustments.
+  - **Import via OCR**: Quickly create entries by importing documents and extracting text with [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR).
 - **Financial Reports**
   - **General Ledger**: Centralized record of all financial transactions, providing a comprehensive view of accounts.
   - **Profit and Loss Statement**: Summarizes revenues, costs, and expenses to show business profitability.
@@ -89,6 +90,20 @@ brew install --cask frappe-books
     <img width='120' alt='Get it on Flathub' src='https://flathub.org/api/badge?locale=en'/>
 </a>
 
+### Using Docker
+
+A `Dockerfile` is included for running Frappe Books in a container with
+PaddleOCR pre-installed.
+
+```bash
+docker build -t frappe-books .
+docker run -it --rm -e DISPLAY=$DISPLAY \
+  -v /tmp/.X11-unix:/tmp/.X11-unix frappe-books
+```
+
+Windows users can start an X server (e.g. VcXsrv) and double-click
+`scripts\run-container.cmd` to launch the container.
+
 ## Development Setup
 
 ### Pre-requisites
@@ -97,6 +112,8 @@ To get the dev environment up and running you need to first set up Node.js `v20.
 [nvm](https://github.com/nvm-sh/nvm#installing-and-updating).
 
 Next, you will need to install [yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable).
+
+If you want to use the optional OCR import feature, make sure you have **Python 3.8+** available on your system.
 
 ### Clone and Run
 
@@ -112,6 +129,9 @@ cd books
 
 # install dependencies
 yarn
+
+# (optional) enable OCR import
+pip install paddleocr
 ```
 
 To run Frappe Books in development mode (with hot reload, etc):

--- a/build/scripts/dev.mjs
+++ b/build/scripts/dev.mjs
@@ -123,12 +123,8 @@ async function handleResult(result) {
 }
 
 function runElectron() {
-  const electronProcess = $$`npx electron --inspect=5858 ${path.join(
-    root,
-    'dist_electron',
-    'dev',
-    'main.js'
-  )}`;
+  const electronPath = path.join(root, 'dist_electron', 'dev', 'main.js');
+  const electronProcess = $$`npx electron --inspect=5858 ${electronPath} --no-sandbox`;
 
   electronProcess.on('close', async () => {
     if (isReload) {

--- a/electron-builder-config.mjs
+++ b/electron-builder-config.mjs
@@ -22,6 +22,7 @@ const frappeBooksConfig = {
     { from: 'log_creds.txt', to: '../creds/log_creds.txt' },
     { from: 'translations', to: '../translations' },
     { from: 'templates', to: '../templates' },
+    { from: 'scripts/paddleocr_cli.py', to: '../paddleocr_cli.py' },
   ],
   files: '**',
   extends: null,

--- a/scripts/paddleocr_cli.py
+++ b/scripts/paddleocr_cli.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import sys
+import json
+
+try:
+    from paddleocr import PaddleOCR
+except Exception as e:
+    print(
+        json.dumps({"error": f"PaddleOCR not installed: {e}"}),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+def main():
+    if len(sys.argv) < 2:
+        print('Usage: paddleocr_cli.py <image>', file=sys.stderr)
+        return 1
+    image_path = sys.argv[1]
+    ocr = PaddleOCR(use_angle_cls=False, use_space_char=True, use_gpu=False)
+    result = ocr.ocr(image_path, cls=False)
+    texts = []
+    for res in result:
+        for line in res:
+            if len(line) >= 2:
+                texts.append(line[1][0])
+    print(json.dumps({'text': ' '.join(texts)}, ensure_ascii=False))
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/run-container.cmd
+++ b/scripts/run-container.cmd
@@ -1,0 +1,4 @@
+@echo off
+REM Run Frappe Books in Docker (requires Docker Desktop and an X server like VcXsrv)
+docker build -t frappe-books .
+docker run --rm -e DISPLAY=host.docker.internal:0.0 -p 6969:6969 frappe-books

--- a/src/pages/ListView/ListView.vue
+++ b/src/pages/ListView/ListView.vue
@@ -4,6 +4,9 @@
       <Button ref="exportButton" :icon="false" @click="openExportModal = true">
         {{ t`Export` }}
       </Button>
+      <Button ref="importButton" :icon="false" @click="importImage">
+        {{ t`Import` }}
+      </Button>
       <FilterDropdown
         ref="filterDropdown"
         :schema-name="schemaName"
@@ -51,6 +54,8 @@ import Modal from 'src/components/Modal.vue';
 import PageHeader from 'src/components/PageHeader.vue';
 import { fyo } from 'src/initFyo';
 import { shortcutsKey } from 'src/utils/injectionKeys';
+import { ocrBuffer } from 'src/utils/ocr';
+import { showToast } from 'src/utils/interactive';
 import {
   docsPathMap,
   getCreateFiltersFromListViewFilters,
@@ -162,6 +167,27 @@ export default defineComponent({
     },
     applyFilter(filters: QueryFilter) {
       this.list?.updateData(filters);
+    },
+    async importImage() {
+      const { canceled, success, data } = await ipc.selectFile({
+        title: this.t`Select Image`,
+        filters: [
+          { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'bmp'] },
+        ],
+      });
+
+      if (canceled || !success || !data) {
+        return;
+      }
+
+      try {
+        const text = await ocrBuffer(data);
+        console.log('OCR output:', text);
+        showToast({ message: text, type: 'success', duration: 'long' });
+      } catch (error) {
+        console.error(error);
+        showToast({ message: this.t`Import failed`, type: 'error' });
+      }
     },
   },
 });

--- a/src/utils/ocr.ts
+++ b/src/utils/ocr.ts
@@ -1,0 +1,72 @@
+import { t } from 'fyo';
+import fs from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { execFile } from 'child_process';
+
+/**
+ * Run OCR on the provided image buffer using the official PaddleOCR
+ * Python package. Requires `paddleocr` to be installed in the system
+ * Python environment.
+ */
+export async function ocrBuffer(buffer: Buffer): Promise<string> {
+  const tmpPath = path.join(tmpdir(), `ocr-${randomUUID()}`);
+  const imagePath = path.join(tmpPath, 'input.png');
+
+  const devScript = path.join(__dirname, '../../scripts/paddleocr_cli.py');
+  const prodScript = path.join(process.resourcesPath, 'paddleocr_cli.py');
+  const scriptPath = fs.existsSync(prodScript) ? prodScript : devScript;
+
+  await fs.mkdir(tmpPath, { recursive: true });
+  await fs.writeFile(imagePath, buffer);
+
+  try {
+    const pythonCmds =
+      process.platform === 'win32'
+        ? ['python', 'python3', 'py']
+        : ['python3', 'python'];
+
+    const { stdout } = await new Promise<{ stdout: string }>(
+      (resolve, reject) => {
+        const tryRun = (cmds: string[]): void => {
+          if (cmds.length === 0) {
+            reject(new Error('Python is not installed'));
+            return;
+          }
+
+          const cmd = cmds[0];
+          execFile(
+            cmd,
+            [scriptPath, imagePath],
+            { encoding: 'utf8' },
+            (err, stdout, stderr) => {
+              if (err) {
+                if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+                  // try next command
+                  tryRun(cmds.slice(1));
+                } else {
+                  console.error(stderr);
+                  reject(err);
+                }
+                return;
+              }
+              resolve({ stdout });
+            }
+          );
+        };
+
+        tryRun(pythonCmds);
+      }
+    );
+
+    const { text } = JSON.parse(stdout) as { text: string };
+    console.log('OCR result:', text);
+    return text;
+  } catch (error) {
+    console.error('PaddleOCR error', error);
+    throw new Error(t`OCR failed: ${String(error)}`);
+  } finally {
+    await fs.rm(tmpPath, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Summary
- add Python helper `paddleocr_cli.py`
- call helper from `ocrBuffer`
- bundle OCR script in build config
- add instructions for installing PaddleOCR and Python
- include OCR bullet in README
- add Dockerfile and Windows helper script
- log OCR results to console when importing
- launch Electron with `--no-sandbox` in dev script

## Testing
- `yarn install` *(fails: better-sqlite3 couldn't be built)*
- `yarn test` *(fails: `/usr/bin/env: ‘zsh’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6874b6c6890c83278045e1fcff690229